### PR TITLE
get_df returns df with common column order

### DIFF
--- a/pycaiso/oasis.py
+++ b/pycaiso/oasis.py
@@ -86,6 +86,25 @@ class Oasis:
             df (pandas.DataFrame): pandas dataframe
         """
 
+        COLUMNS = [
+            "INTERVALSTARTTIME_GMT",
+            "INTERVALENDTIME_GMT",
+            "OPR_DT",
+            "OPR_HR",
+            "OPR_INTERVAL",
+            "NODE_ID_XML",
+            "NODE_ID",
+            "NODE",
+            "MARKET_RUN_ID",
+            "LMP_TYPE",
+            "XML_DATA_ITEM",
+            "PNODE_RESMRID",
+            "GRP_TYPE",
+            "POS",
+            "MW",
+            "GROUP",
+        ]
+
         with io.BytesIO() as buffer:
             try:
                 buffer.write(response.content)
@@ -102,7 +121,7 @@ class Oasis:
                 if sort_values:
                     df = df.sort_values(sort_values).reset_index(drop=True)
 
-        return df
+        return df.reindex(columns=COLUMNS)
 
 
 class Node(Oasis):


### PR DESCRIPTION
This change makes the dataframe columns in the same order regardless of which market is selected. By default, a call to the day ahead market (DAM) and a call to the real time market (RTM) will have the same columns but in different order. 

By having the dataframes in the same order, they can share a single table/schema in Postgres. 